### PR TITLE
[FIX] base_external_dbsource_mysql: Pin version of MySQLdb

### DIFF
--- a/setup/base_external_dbsource_mysql/setup.py
+++ b/setup/base_external_dbsource_mysql/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     odoo_addon={
         'external_dependencies_override': {
             'python': {
-                'MySQLdb': 'mysqlclient',
+                'MySQLdb': 'mysqlclient==2.0.1',
             }
         },
     }


### PR DESCRIPTION
Thanks for the PR, I fixed the version because it is fixed in https://github.com/OCA/server-backend/blob/56fba17abc90466e9d9f31dfaa5578940cca7083/requirements.txt#L2